### PR TITLE
Support substreams with parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build": "tsup src/index.ts --dts",
     "test": "tsx --test **/*.spec.ts",
     "prepublishOnly": "npm run test && npm run build",
-    "codegen": "buf generate buf.build/streamingfast/substreams:develop && buf generate proto"
+    "codegen": "buf generate buf.build/streamingfast/substreams && buf generate proto"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
# Feature
Substreams can now handle custom parameters contained within the packaged file.
This pull request add the ability to specifiy custom parameters to substream modules that supports it within a given package.

# Example
Given a substream like this (taken from the `params` example of [Pinax's substreams](https://github.com/pinax-network/substreams/)):
```rust
#[substreams::handlers::map]
pub fn map_params(params: String, clock: Clock) -> Result<Clock, Error> {
    log::debug!("map_params: {:?}", params);
    Ok(clock)
}
```

You can specify custom parameters by using the `params` attribute in the `start()` function.
```ts
// Download Substream from URL or IPFS
const spkg = await download(url)

// Initialize Substreams
const substreams = new Substreams(spkg, 'map_params', {
    authorization: api_token
})

substreams.start(
    undefined, // startDelay set to None
    [{
        moduleName: 'map_params',
        value: 'test'
    }]
)
```